### PR TITLE
Optimizer

### DIFF
--- a/src/compile/bytes.rs
+++ b/src/compile/bytes.rs
@@ -1,7 +1,8 @@
 use vm::*;
 use syntax::*;
 use errors::*;
-use compile::Compile;
+use common::*;
+use compile::{Compile, Optimize};
 use std::rc::Rc;
 use std::collections::HashMap;
 
@@ -9,12 +10,12 @@ use std::collections::HashMap;
 /// gathered, and then filled in.
 type BoringTable = HashMap<String, Option<Fun>>;
 
-pub struct CompileBytes<'ast> {
-    ast: &'ast AST,
+pub struct CompileBytes {
+    ast: AST,
     fun_table: BoringTable,
 }
 
-impl<'ast> Compile for CompileBytes<'ast> {
+impl Compile for CompileBytes {
     type Out = FunTable;
     /// Consumes the compiler, producing a `FunTable` on success or message on
     /// error.
@@ -46,14 +47,14 @@ impl<'ast> Compile for CompileBytes<'ast> {
         Ok(
             self.fun_table
                 .into_iter()
-                .map(|(k, v)| (k, Rc::new(v.unwrap())))
+                .map(|(k, v)| (k, v.unwrap()))
                 .collect(),
         )
     }
 }
 
-impl<'ast> CompileBytes<'ast> {
-    pub fn new(ast: &'ast AST) -> Self {
+impl CompileBytes {
+    pub fn new(ast: AST) -> Self {
         CompileBytes {
             ast,
             fun_table: BoringTable::new(),
@@ -123,7 +124,7 @@ impl<'ast> CompileBytes<'ast> {
         Ok(())
     }
 
-    fn compile_block(&self, block: &'ast Block, jmp_offset: usize) -> Result<BcBody> {
+    fn compile_block(&self, block: &Block, jmp_offset: usize) -> Result<BcBody> {
         let mut body = vec![];
         for stmt in &block.block {
             match *stmt {
@@ -184,7 +185,7 @@ impl<'ast> CompileBytes<'ast> {
         Ok(body.into_iter().map(Option::unwrap).collect())
     }
 
-    fn compile_stack_stmt(&self, stmt: &'ast StackStmt) -> Result<BcBody> {
+    fn compile_stack_stmt(&self, stmt: &StackStmt) -> Result<BcBody> {
         let mut body = BcBody::new();
         for action in &stmt.stack_actions {
             match *action {
@@ -201,7 +202,7 @@ impl<'ast> CompileBytes<'ast> {
         Ok(body)
     }
 
-    fn compile_item_push(&self, item: &'ast Item) -> Result<BcBody> {
+    fn compile_item_push(&self, item: &Item) -> Result<BcBody> {
         match item.item_type {
             ItemType::Stack(_) => self.compile_local_stack(item),
             ItemType::Ident(ref ident) => {
@@ -215,7 +216,7 @@ impl<'ast> CompileBytes<'ast> {
         }
     }
 
-    fn compile_local_stack(&self, item: &'ast Item) -> Result<BcBody> {
+    fn compile_local_stack(&self, item: &Item) -> Result<BcBody> {
         assert_matches!(item.item_type, ItemType::Stack(_));
         let items = if let ItemType::Stack(ref stack) = item.item_type {
             stack
@@ -235,3 +236,125 @@ impl<'ast> CompileBytes<'ast> {
         }
     }
 }
+
+/// An optimizer that inlines functions.
+pub struct OptimizeInline {
+    fun_table: FunTable,
+    to_inline: HashMap<String, BcBody>,
+}
+
+impl Optimize for OptimizeInline {
+    type Out = FunTable;
+
+    fn optimize(mut self) -> Self::Out {
+        self.determine_inlines();
+        self.replace_inlines();
+        self.snip_inlines();
+
+        self.fun_table
+    }
+}
+
+impl OptimizeInline {
+    pub fn new(fun_table: FunTable) -> Self {
+        OptimizeInline {
+            fun_table,
+            to_inline: HashMap::new(),
+        }
+    }
+    /// Determines whether a given function should be inlined.
+    fn should_inline(fun: &Fun) -> bool {
+        const SKIP: &[&'static str] = &["main"]; // function names to skip and not inline
+        if let &Fun::UserFun(ref fun) = fun as &Fun {
+            !SKIP.contains(&fun.name.as_str())
+                && !fun.body.iter().any(|bc| bc.bc_type == BcType::Call)
+        }
+        else {
+            false
+        }
+    }
+
+    fn is_inline_call(&self, bc: &Bc) -> bool {
+        if let &Some(Val::Ident(ref fname)) = &bc.val {
+            bc.bc_type == BcType::Call && self.to_inline.contains_key(fname)
+        }
+        else {
+            false
+        }
+    }
+
+    /// Determines which functions to inline.
+    /// Functions are inlined if they don't call another function.
+    fn determine_inlines(&mut self) {
+        for (ref fname, ref fun) in &self.fun_table {
+            if Self::should_inline(fun) {
+                let ref fun_body = fun.user_fun()
+                    .body;
+                // this gets all except the last instruction, which is the 'RET' instruction which
+                // messes things up a little bit.
+                let body_clone = fun_body.clone()
+                    .iter()
+                    .cloned()
+                    .take(fun_body.len() - 1)
+                    .collect::<Vec<_>>();
+                self.to_inline.insert(fname.to_string(), body_clone);
+            }
+        }
+    }
+
+    fn replace_inlines(&mut self) {
+        let mut to_optimize = vec![];
+        // this section determines which functions we're going to apply optimizations to
+        {
+            for (ref fname, ref fun) in &self.fun_table {
+                // if this fname is *not* in the list of things to inline
+                if !self.to_inline.contains_key(fname.as_str())
+                    // this checks if a user function has a call to one of the inlines
+                    && fun.is_user_fun()
+                    && fun.user_fun().body.iter().any(|bc| self.is_inline_call(bc)) {
+                    to_optimize.push(fname.to_string());
+                }
+            }
+        }
+
+        // this section applies optimizations
+        for fname in to_optimize {
+            let mut new_body = vec![];
+            {
+                let fun = self.fun_table
+                    .get(&fname)
+                    .unwrap();
+                let ref body = (fun as &Fun).user_fun()
+                    .body;
+                for bc in body {
+                    if self.is_inline_call(bc) {
+                        let call_name = bc.clone()
+                            .val
+                            .unwrap()
+                            .ident()
+                            .to_string();
+                        new_body.append(&mut self.to_inline.get(&call_name).unwrap().clone());
+                    }
+                    else {
+                        new_body.push(bc.clone());
+                    }
+                }
+            }
+
+            let tokens = self.fun_table
+                .get(&fname)
+                .unwrap()
+                .user_fun()
+                .tokens.clone();
+
+            // replace the function with the new body
+            self.fun_table.insert(fname.clone(),
+                                  Fun::UserFun(Rc::new(UserFun::new(fname, new_body, tokens))));
+        }
+
+    }
+
+    fn snip_inlines(&mut self) {
+    }
+}
+

--- a/src/compile/bytes.rs
+++ b/src/compile/bytes.rs
@@ -251,7 +251,6 @@ impl Optimize for OptimizeInline {
     fn optimize(mut self) -> Self::Out {
         self.determine_inlines();
         self.replace_inlines();
-        self.snip_inlines();
 
         self.fun_table
     }
@@ -349,6 +348,4 @@ impl OptimizeInline {
         }
 
     }
-
-    fn snip_inlines(&mut self) {}
 }

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -16,4 +16,3 @@ pub trait Optimize {
 }
 
 pub use bytes::*;
-

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -1,0 +1,14 @@
+pub mod bytes;
+pub mod optimize;
+
+use errors::*;
+
+/// A general compiler trait.
+pub trait Compile {
+    type Out;
+
+    fn compile(self) -> Result<Self::Out>;
+}
+
+pub use bytes::*;
+pub use optimize::*;

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -1,5 +1,4 @@
 pub mod bytes;
-pub mod optimize;
 
 use errors::*;
 
@@ -10,5 +9,11 @@ pub trait Compile {
     fn compile(self) -> Result<Self::Out>;
 }
 
+pub trait Optimize {
+    type Out;
+
+    fn optimize(self) -> Self::Out;
+}
+
 pub use bytes::*;
-pub use optimize::*;
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,11 @@ fn run_program<P: AsRef<Path>, Q: AsRef<Path>>(
     let filled_ast = process_source_path(path, search_dirs).chain_err(
         || "Parse error",
     )?;
-    let compiler = CompileBytes::new(&filled_ast)
+    let compiler = CompileBytes::new(filled_ast)
         .builtins(&*BUILTINS);
     let fun_table = compiler.compile().chain_err(|| "Compile error")?;
+    let fun_table = OptimizeInline::new(fun_table)
+        .optimize();
     if dump {
         for f in fun_table.iter().filter_map(
             |(_, f)| if let &Fun::UserFun(ref f) =

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate libc;
 extern crate libffi;
 
 mod syntax;
+mod compile;
 mod vm;
 #[macro_use]
 mod common;
@@ -40,6 +41,7 @@ mod errors {
 use common::*;
 use errors::*;
 use vm::*;
+use compile::*;
 use std::process;
 use std::env;
 use std::path::Path;
@@ -52,7 +54,8 @@ fn run_program<P: AsRef<Path>, Q: AsRef<Path>>(
     let filled_ast = process_source_path(path, search_dirs).chain_err(
         || "Parse error",
     )?;
-    let compiler = Compiler::new(&filled_ast);
+    let compiler = CompileBytes::new(&filled_ast)
+        .builtins(&*BUILTINS);
     let fun_table = compiler.compile().chain_err(|| "Compile error")?;
     if dump {
         for f in fun_table.iter().filter_map(

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 pub type BuiltinFun = fn(&mut State) -> Result<()>;
 
 lazy_static! {
-    pub(in vm) static ref BUILTINS: HashMap<&'static str, BuiltinFun> = {
+    pub static ref BUILTINS: HashMap<&'static str, BuiltinFun> = {
         hashmap! {
             // Operations
             "+" => plus as BuiltinFun,  // for some reason this cascades down the list

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -245,12 +245,29 @@ impl UserFun {
                 if let Some(ref payload) = bc.val { format!("{:?}", payload) } else { format!("") });
         }
     }
+
+    pub fn replace_body(&mut self, body: BcBody) {
+        self.body = body;
+    }
 }
 
+#[derive(EnumIsA)]
 pub enum Fun {
     UserFun(Rc<UserFun>),
     ForeignFun(ForeignFn),
     BuiltinFun(&'static BuiltinFun),
 }
 
-pub type FunTable = HashMap<String, Rc<Fun>>;
+impl Fun {
+    pub fn user_fun(&self) -> &UserFun {
+        if let &Fun::UserFun(ref fun) = self {
+            fun
+        }
+        else {
+            panic!("Fun::user_fun() called on non-UserFun item")
+        }
+    }
+}
+
+pub type FunTable = HashMap<String, Fun>;
+pub type FunRcTable = HashMap<String, Rc<Fun>>;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -262,8 +262,7 @@ impl Fun {
     pub fn user_fun(&self) -> &UserFun {
         if let &Fun::UserFun(ref fun) = self {
             fun
-        }
-        else {
+        } else {
             panic!("Fun::user_fun() called on non-UserFun item")
         }
     }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -245,10 +245,6 @@ impl UserFun {
                 if let Some(ref payload) = bc.val { format!("{:?}", payload) } else { format!("") });
         }
     }
-
-    pub fn replace_body(&mut self, body: BcBody) {
-        self.body = body;
-    }
 }
 
 #[derive(EnumIsA)]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,11 +1,9 @@
-mod compile;
 mod vm;
 mod builtins;
 mod foreign;
 
-pub use self::compile::*;
 pub use self::vm::*;
-pub(in vm) use self::builtins::*;
+pub use self::builtins::*;
 
 use errors::*;
 use syntax::*;

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -142,14 +142,18 @@ impl State {
 }
 
 pub struct VM {
-    fun_table: FunTable,
+    fun_table: FunRcTable,
     state: RefCell<State>,
 }
 
 impl VM {
     pub fn new(fun_table: FunTable) -> Self {
+        let mut rc_table = FunRcTable::new();
+        for (k, v) in fun_table {
+            rc_table.insert(k, Rc::new(v));
+        }
         VM {
-            fun_table,
+            fun_table: rc_table,
             state: RefCell::new(State::new()),
         }
     }

--- a/test.sbl
+++ b/test.sbl
@@ -161,7 +161,7 @@ main {
         $ 0 >
     }
 
-    "testing file writing" !println
-    "hello darkness, my old friend" "test.txt" write-string
-    "status: " !print !println
+    # "testing file writing" !println
+    # "hello darkness, my old friend" "test.txt" write-string
+    # "status: " !print !println
 }


### PR DESCRIPTION
This adds a basic optimizer framework, and includes function inlining. Reference counted functions are no longer used until we get to the VM, because it adds a layer of friction that's a pain to deal with. The compiler has also been re-organized, with all compilation-related stuff in the `compile` module. There is a new command line option in the binary, which can be used to turn off optimization (`-O=no`). Beyond that, some miscellaneous/unrelated warnings have been fixed.

Closes #13.